### PR TITLE
Add styling for vim fat-cursor

### DIFF
--- a/Zenburn.less
+++ b/Zenburn.less
@@ -55,7 +55,11 @@
 }
 
 .CodeMirror-cursor {
-    border-left: 1px solid #fff !important;
+    border-left: 1px solid #fff;
+}
+.cm-keymap-fat-cursor .CodeMirror-cursor {
+    border-left: none;
+    background: rgba(255, 255, 255, 0.5);
 }
 
 .CodeMirror-gutters {


### PR DESCRIPTION
I'm using Vimderbar with this theme and wanted to provide a style for the fat-cursor mode in CodeMirror vim.

The !important flag on the cursor border-left was preventing me from removing the border when in fat-cursor mode. It seems to not be necessary at all because the themes engine in Brackets applies the theme styles with an id selector, which raises the specificity enough to not need !important.
